### PR TITLE
refactor: Replace interface{} by any

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ func main() {
 
     cache.Set("key", "value")
     cache.SetWithTTL("key-with-ttl", "value", 60*time.Minute)
-    cache.SetAll(map[string]interface{}{"k1": "v1", "k2": "v2", "k3": "v3"})
+    cache.SetAll(map[string]any{"k1": "v1", "k2": "v2", "k3": "v3"})
 
     fmt.Println("[Count] Cache size:", cache.Count())
 

--- a/entry.go
+++ b/entry.go
@@ -12,7 +12,7 @@ type Entry struct {
 	Key string
 
 	// Value is the value of the cache entry
-	Value interface{}
+	Value any
 
 	// RelevantTimestamp is the variable used to store either:
 	// - creation timestamp, if the Cache's EvictionPolicy is FirstInFirstOut
@@ -48,7 +48,7 @@ func (entry *Entry) SizeInBytes() int {
 	return toBytes(entry.Key) + toBytes(entry.Value) + 32
 }
 
-func toBytes(value interface{}) int {
+func toBytes(value any) int {
 	switch value.(type) {
 	case string:
 		return int(unsafe.Sizeof(value)) + len(value.(string))
@@ -60,9 +60,9 @@ func toBytes(value interface{}) int {
 		return int(unsafe.Sizeof(value)) + 4
 	case int64, uint64, int, uint, float64, complex128:
 		return int(unsafe.Sizeof(value)) + 8
-	case []interface{}:
+	case []any:
 		size := 0
-		for _, v := range value.([]interface{}) {
+		for _, v := range value.([]any) {
 			size += toBytes(v)
 		}
 		return int(unsafe.Sizeof(value)) + size

--- a/entry_test.go
+++ b/entry_test.go
@@ -62,10 +62,10 @@ func TestEntry_SizeInBytes(t *testing.T) {
 	testSizeInBytes(t, "k", struct{ A string }{A: "hello"}, 72)
 	testSizeInBytes(t, "k", struct{ A, B string }{A: "hello", B: "world"}, 78)
 	testSizeInBytes(t, "k", nil, 70)
-	testSizeInBytes(t, "k", make([]interface{}, 5), 170)
+	testSizeInBytes(t, "k", make([]any, 5), 170)
 }
 
-func testSizeInBytes(t *testing.T, key string, value interface{}, expectedSize int) {
+func testSizeInBytes(t *testing.T, key string, value any, expectedSize int) {
 	t.Run(fmt.Sprintf("%T_%d", value, expectedSize), func(t *testing.T) {
 		if size := (&Entry{Key: key, Value: value}).SizeInBytes(); size != expectedSize {
 			t.Errorf("expected size of entry with key '%v' and value '%v' (%T) to be %d, got %d", key, value, value, expectedSize, size)

--- a/gocache_bench_test.go
+++ b/gocache_bench_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func BenchmarkMap_Get(b *testing.B) {
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 	for n := 0; n < b.N; n++ {
 		_, _ = m[strconv.Itoa(n)]
 	}
@@ -24,7 +24,7 @@ func BenchmarkMap_Set(b *testing.B) {
 	}
 	for name, value := range values {
 		b.Run(fmt.Sprintf("%s value", name), func(b *testing.B) {
-			m := make(map[string]interface{})
+			m := make(map[string]any)
 			for n := 0; n < b.N; n++ {
 				m[strconv.Itoa(n)] = value
 			}

--- a/gocache_test.go
+++ b/gocache_test.go
@@ -336,7 +336,7 @@ func TestCache_SetGetStruct(t *testing.T) {
 
 func TestCache_SetAll(t *testing.T) {
 	cache := NewCache().WithMaxSize(NoMaxSize)
-	cache.SetAll(map[string]interface{}{"k1": "v1", "k2": "v2"})
+	cache.SetAll(map[string]any{"k1": "v1", "k2": "v2"})
 	value, ok := cache.Get("k1")
 	if !ok {
 		t.Error("expected key to exist")
@@ -351,7 +351,7 @@ func TestCache_SetAll(t *testing.T) {
 	if value != "v2" {
 		t.Errorf("expected: %s, but got: %s", "v2", value)
 	}
-	cache.SetAll(map[string]interface{}{"k1": "updated"})
+	cache.SetAll(map[string]any{"k1": "updated"})
 	value, ok = cache.Get("k1")
 	if !ok {
 		t.Error("expected key to exist")
@@ -949,7 +949,7 @@ func TestCache_MemoryUsageIsReliable(t *testing.T) {
 		t.Error("cache.MemoryUsage() should've increased")
 	}
 	previousCacheMemoryUsage = cache.MemoryUsage()
-	cache.SetAll(map[string]interface{}{"2": "2", "3": "3", "4": "4"})
+	cache.SetAll(map[string]any{"2": "2", "3": "3", "4": "4"})
 	if cache.MemoryUsage() <= previousCacheMemoryUsage {
 		t.Error("cache.MemoryUsage() should've increased")
 	}
@@ -1003,7 +1003,7 @@ func TestCache_WithForceNilInterfaceOnNilPointer(t *testing.T) {
 		t.Error("expected key to exist")
 	} else {
 		if value != nil {
-			// the value is not nil, because cache.Get returns an interface{}, and the type of that interface is not nil
+			// the value is not nil, because cache.Get returns an interface{} (any), and the type of that interface is not nil
 			t.Error("value should be nil")
 		}
 	}


### PR DESCRIPTION
## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->
This replaces the type `interface{}` by `any` - an alias type for `interface{}` introduced in Go 1.18.

This does not change how anything works, but it is slightly more readable.

## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [X] Added the documentation in `README.md`, if applicable.
